### PR TITLE
Do not modify rack env unless redirect option is used.

### DIFF
--- a/lib/rack/i18n_locale_switcher.rb
+++ b/lib/rack/i18n_locale_switcher.rb
@@ -91,8 +91,8 @@ module Rack
     
     def extract_locale_from_param(env)
       query_string = env['QUERY_STRING'].gsub(/\b#{ @param }=#{ LOCALE_PATTERN }(?:&|$)/, '')
-
-      if locale = available_locale($1, $2)
+      locale = available_locale($1, $2)
+      if locale && @redirect
         env['QUERY_STRING'] = query_string.gsub(/&$/, '')        
       end
       locale
@@ -100,8 +100,8 @@ module Rack
 
     def extract_locale_from_path(env)
       path_info = env['PATH_INFO'].gsub(/^\/#{ LOCALE_PATTERN }\b/, '')
-
-      if locale = available_locale($1, $2)
+      locale = available_locale($1, $2)
+      if locale && @redirect
         env['PATH_INFO'] = path_info
       end
       locale
@@ -111,8 +111,8 @@ module Rack
       env['HTTP_HOST'] ||= "#{ env['SERVER_NAME'] }:#{ env['SERVER_PORT'] }"            
 
       http_host = env['HTTP_HOST'].gsub(/^#{ LOCALE_PATTERN }\./, '')
-
-      if locale = available_locale($1, $2)
+      locale = available_locale($1, $2)
+      if locale && @redirect
         env['HTTP_HOST']   = http_host
         env['SERVER_NAME'] = http_host.gsub(/:\d+$/, '')
       end

--- a/lib/rack/i18n_locale_switcher.rb
+++ b/lib/rack/i18n_locale_switcher.rb
@@ -85,7 +85,7 @@ module Rack
 
       if @save_to_cookie
         status, headers, body, *rest = @app.call(env)
-         save_locale_in_cookies(headers) if @save_to_cookie
+        save_locale_in_cookies(headers)
         [status, headers, body, *rest]
       else
         @app.call(env)
@@ -135,11 +135,15 @@ module Rack
       locale
     end
 
+    REGEXP_LOCALE_PATTERN = Regexp.new(LOCALE_PATTERN)
+
     def extract_locale_from_cookie(env)
-      return unless (env_cookies = parse_cookies(env))
-      return unless (cookie = env_cookies[@cookie])
-      return unless Regexp.new(LOCALE_PATTERN).match(cookie)
+      return unless REGEXP_LOCALE_PATTERN.match(cookies(env)[@cookie])
       available_locale($1, $2)
+    end
+
+    def cookies(env)
+      parse_cookies(env) || {}
     end
 
     def set_locale_in_param(env)

--- a/spec/rack/i18n_locale_switcher_spec.rb
+++ b/spec/rack/i18n_locale_switcher_spec.rb
@@ -86,6 +86,17 @@ describe Rack::I18nLocaleSwitcher do
       I18n.locale.should eql(:es)
     end
 
+    it 'should not change the query string unless redirect is used' do
+      get "http://example.com?locale=de"
+      last_request.env['QUERY_STRING'].should eql('locale=de')
+
+      get "http://example.com?locale=en-US"
+      last_request.env['QUERY_STRING'].should eql('locale=en-US')
+
+      get "http://example.com/some/path?foo=bar&locale=es&param=value"
+      last_request.env['QUERY_STRING'].should eql('foo=bar&locale=es&param=value')
+    end
+
     it "should not set an unavailable locale" do
       get "http://example.com?locale=xx"
       I18n.locale.should eql(I18n.default_locale)
@@ -113,6 +124,14 @@ describe Rack::I18nLocaleSwitcher do
       get "http://example.com/en-us"
       I18n.locale.should eql(:'en-US')
     end
+
+    it 'should not change path if not using redirect' do
+      get "http://example.com/de/some/path/"
+      last_request.env['PATH_INFO'].should eql('/de/some/path/')
+
+      get "http://example.com/en-us"
+      last_request.env['PATH_INFO'].should eql('/en-us')
+    end
   end
 
   context "from host" do
@@ -123,6 +142,17 @@ describe Rack::I18nLocaleSwitcher do
 
       get "http://de-de.example.com/"
       I18n.locale.should eql(:'de-DE')
+    end
+
+    it "should not change host if not using redirect" do
+      get "http://de.example.com/"
+      last_request.env['SERVER_NAME'].should eql('de.example.com')
+      last_request.env['HTTP_HOST'].should eql('de.example.com')
+
+      get "http://de-de.example.com/"
+      I18n.locale.should eql(:'de-DE')
+      last_request.env['SERVER_NAME'].should eql('de-de.example.com')
+      last_request.env['HTTP_HOST'].should eql('de-de.example.com')
     end
   end
 

--- a/spec/rack/i18n_locale_switcher_spec.rb
+++ b/spec/rack/i18n_locale_switcher_spec.rb
@@ -8,13 +8,13 @@ describe Rack::I18nLocaleSwitcher do
   let :options do
     {}
   end
-  
+
   let :app do
     opts = options
     rack = Rack::Builder.new do
       map "/" do
         use Rack::I18nLocaleSwitcher, opts
-        run lambda { |env| [200, {}, "Coolness"] }
+        run lambda {|env| [200, {}, "Coolness"]}
       end
     end
     rack.to_app
@@ -32,32 +32,32 @@ describe Rack::I18nLocaleSwitcher do
     get "http://www.example.com/"
     I18n.locale.should eql(I18n.default_locale)
   end
-  
+
   it "should not accept invalid options" do
-    expect { 
-      Rack::I18nLocaleSwitcher.new("app", :not_an_option => "foo") 
+    expect {
+      Rack::I18nLocaleSwitcher.new("app", :not_an_option => "foo")
     }.to raise_error(ArgumentError, "Invalid option(s) :not_an_option")
 
-    expect { 
-      Rack::I18nLocaleSwitcher.new("app", :source => [ :not_a_source ]) 
+    expect {
+      Rack::I18nLocaleSwitcher.new("app", :source => [:not_a_source])
     }.to raise_error(ArgumentError, "Invalid source(s) :not_a_source")
 
-    expect { 
-      Rack::I18nLocaleSwitcher.new("app", :redirect => :not_a_source) 
+    expect {
+      Rack::I18nLocaleSwitcher.new("app", :redirect => :not_a_source)
     }.to raise_error(ArgumentError, "Invalid redirect option :not_a_source")
   end
-  
+
   context "with custom sources" do
-    
+
     let :options do
-      { :source => [ :header, :host ] }
+      { :source => [:header, :host] }
     end
-    
+
     it "should honor the sequence" do
-      get "http://de.example.com" , nil, {"HTTP_ACCEPT_LANGUAGE" => "es"}
+      get "http://de.example.com", nil, { "HTTP_ACCEPT_LANGUAGE" => "es" }
       I18n.locale.should eql(:es)
 
-      get "http://de.example.com" , nil, {"HTTP_ACCEPT_LANGUAGE" => "foo"}
+      get "http://de.example.com", nil, { "HTTP_ACCEPT_LANGUAGE" => "foo" }
       I18n.locale.should eql(:de)
 
       get "http://de.example.com"
@@ -90,13 +90,13 @@ describe Rack::I18nLocaleSwitcher do
       get "http://example.com?locale=xx"
       I18n.locale.should eql(I18n.default_locale)
     end
-    
+
     context "name" do
-      
+
       let :options do
         { :param => "lang" }
       end
-      
+
       it "should be configurable" do
         get "http://example.com?lang=de"
         I18n.locale.should eql(:de)
@@ -129,14 +129,27 @@ describe Rack::I18nLocaleSwitcher do
   context "from accept-language header" do
 
     it "should override the client requested locale" do
-      get "http://example.com" , nil, {"HTTP_ACCEPT_LANGUAGE" => "de-de,de,en;q=0.5"}
+      get "http://example.com", nil, { "HTTP_ACCEPT_LANGUAGE" => "de-de,de,en;q=0.5" }
       I18n.locale.should eql(:'de-DE')
 
-      get "http://example.com" , nil, {"HTTP_ACCEPT_LANGUAGE" => "en;q=0.5,en-US;q=0.8,es;q=0.7"}
+      get "http://example.com", nil, { "HTTP_ACCEPT_LANGUAGE" => "en;q=0.5,en-US;q=0.8,es;q=0.7" }
       I18n.locale.should eql(:'en-US')
     end
   end
-  
+
+  context "from cookie" do
+    it "should set the i18n locale" do
+      get "http://example.com", nil, { "HTTP_COOKIE" => "locale=de-de" }
+      I18n.locale.should eql(:'de-DE')
+
+      get "http://example.com", nil, { "HTTP_COOKIE" => "locale=en-US" }
+      I18n.locale.should eql(:'en-US')
+
+      get "http://example.com", nil, { "HTTP_COOKIE" => "" }
+      I18n.locale.should eql(I18n.default_locale)
+    end
+  end
+
   shared_examples_for "a redirect with the default locale" do
 
     it "should redirect to the canonical URL" do
@@ -152,17 +165,17 @@ describe Rack::I18nLocaleSwitcher do
     end
 
     it "should not redirect if the locale was set in the accept header" do
-      get "http://example.com" , nil, {"HTTP_ACCEPT_LANGUAGE" => "en"}
+      get "http://example.com", nil, { "HTTP_ACCEPT_LANGUAGE" => "en" }
       last_response.should_not be_redirect
     end
   end
-  
+
   context "redirect to path" do
 
     let :options do
       { :redirect => :path }
     end
-    
+
     it "should not redirect if the locale was set with the path" do
       %w{ 
         http://example.com/de
@@ -174,12 +187,12 @@ describe Rack::I18nLocaleSwitcher do
         last_response.should_not be_redirect
       end
     end
-    
+
     it "should redirect if the locale was set by other means" do
       {
-        "http://en.example.com"        => "http://example.com/en",
-        "http://en.example.com/de"     => "http://example.com/de",
-        "http://de.example.com"        => "http://example.com/de",
+        "http://en.example.com" => "http://example.com/en",
+        "http://en.example.com/de" => "http://example.com/de",
+        "http://de.example.com" => "http://example.com/de",
         "http://example.com?locale=de" => "http://example.com/de"
       }.each do |url, redirect_url|
         get url
@@ -187,13 +200,13 @@ describe Rack::I18nLocaleSwitcher do
         last_response.location.should eql(redirect_url)
       end
     end
-    
+
     it "should redirect if the locale was set with an accept header" do
-      get "http://example.com" , nil, {"HTTP_ACCEPT_LANGUAGE" => "de"}
+      get "http://example.com", nil, { "HTTP_ACCEPT_LANGUAGE" => "de" }
       last_response.should be_redirect
       last_response.location.should eql("http://example.com/de")
     end
-    
+
     context "canonical" do
 
       let :options do
@@ -209,7 +222,7 @@ describe Rack::I18nLocaleSwitcher do
     let :options do
       { :redirect => :host }
     end
-    
+
     it "should not redirect if the locale was set with the host" do
       %w{ 
         http://de.example.com
@@ -220,12 +233,12 @@ describe Rack::I18nLocaleSwitcher do
         last_response.should_not be_redirect
       end
     end
-    
+
     it "should redirect if the locale was set by other means" do
       {
-        "http://example.com/en"        => "http://en.example.com",
-        "http://en.example.com/de"     => "http://de.example.com",
-        "http://example.com/de"        => "http://de.example.com",
+        "http://example.com/en" => "http://en.example.com",
+        "http://en.example.com/de" => "http://de.example.com",
+        "http://example.com/de" => "http://de.example.com",
         "http://example.com?locale=de" => "http://de.example.com"
       }.each do |url, redirect_url|
         get url
@@ -235,7 +248,7 @@ describe Rack::I18nLocaleSwitcher do
     end
 
     it "should redirect if the locale was set with an accept header" do
-      get "http://example.com" , nil, {"HTTP_ACCEPT_LANGUAGE" => "de"}
+      get "http://example.com", nil, { "HTTP_ACCEPT_LANGUAGE" => "de" }
       last_response.should be_redirect
       last_response.location.should eql("http://de.example.com")
     end
@@ -266,12 +279,12 @@ describe Rack::I18nLocaleSwitcher do
         last_response.should_not be_redirect
       end
     end
-    
+
     it "should redirect if the locale was set by other means" do
       {
-        "http://example.com/en"           => "http://example.com?locale=en",
-        "http://de.example.com/foo/bar"   => "http://example.com/foo/bar?locale=de",
-        "http://example.com/de"           => "http://example.com?locale=de",
+        "http://example.com/en" => "http://example.com?locale=en",
+        "http://de.example.com/foo/bar" => "http://example.com/foo/bar?locale=de",
+        "http://example.com/de" => "http://example.com?locale=de",
         "http://en.example.com?locale=de" => "http://example.com?locale=de"
       }.each do |url, redirect_url|
         get url
@@ -281,11 +294,11 @@ describe Rack::I18nLocaleSwitcher do
     end
 
     it "should redirect if the locale was set with an accept header" do
-      get "http://example.com" , nil, {"HTTP_ACCEPT_LANGUAGE" => "de"}
+      get "http://example.com", nil, { "HTTP_ACCEPT_LANGUAGE" => "de" }
       last_response.should be_redirect
       last_response.location.should eql("http://example.com?locale=de")
     end
-          
+
     context "canonical" do
 
       let :options do
@@ -294,21 +307,47 @@ describe Rack::I18nLocaleSwitcher do
 
       it_should_behave_like "a redirect with the default locale"
     end
-    
+
     context "exceptions" do
 
       let :options do
         { :redirect => :path, :except => /^\/assets/ }
       end
-      
+
       it "should not redirect if the path is exempt" do
-        [ "http://example.com/assets",   
-          "http://de.example.com/assets/foo/bar",
-          "http://example.com/assets/"
+        ["http://example.com/assets",
+         "http://de.example.com/assets/foo/bar",
+         "http://example.com/assets/"
         ].each do |url|
           get url
           last_response.should_not be_redirect
         end
+      end
+    end
+  end
+
+  context "save_to_cookie" do
+    let(:options) do
+      { save_to_cookie: true, cookie: 'cookie_name_for_locale' }
+    end
+
+    [
+      ["path", "http://example.com/es"],
+      ["param", "http://example.com", { 'locale' => 'es' }, {}],
+      ["host", "http://es.example.com"],
+      ["headers", "http://example.com", {}, { "HTTP_ACCEPT_LANGUAGE" => "es" }],
+      ["cookie", "http://example.com", {}, { "HTTP_COOKIE" => "cookie_name_for_locale=es" }],
+    ].each do |src, url, params, env|
+      it "should set locale in the cookie header when reading from #{src}" do
+        if params || env
+          get url, params, env
+        else
+          get url
+        end
+        I18n.locale.should eq(:es)
+        last_response.header.should include("Set-Cookie")
+        last_response.header["Set-Cookie"].should match(/cookie_name_for_locale/)
+        last_response.header["Set-Cookie"].should match(/=es/)
       end
     end
   end

--- a/spec/rack/i18n_locale_switcher_spec.rb
+++ b/spec/rack/i18n_locale_switcher_spec.rb
@@ -332,18 +332,14 @@ describe Rack::I18nLocaleSwitcher do
     end
 
     [
-      ["path", "http://example.com/es"],
+      ["path", "http://example.com/es", {}, {}],
       ["param", "http://example.com", { 'locale' => 'es' }, {}],
-      ["host", "http://es.example.com"],
+      ["host", "http://es.example.com", {}, {}],
       ["headers", "http://example.com", {}, { "HTTP_ACCEPT_LANGUAGE" => "es" }],
       ["cookie", "http://example.com", {}, { "HTTP_COOKIE" => "cookie_name_for_locale=es" }],
     ].each do |src, url, params, env|
       it "should set locale in the cookie header when reading from #{src}" do
-        if params || env
-          get url, params, env
-        else
-          get url
-        end
+        get url, params, env
         I18n.locale.should eq(:es)
         last_response.header.should include("Set-Cookie")
         last_response.header["Set-Cookie"].should match(/cookie_name_for_locale/)

--- a/spec/rack/i18n_locale_switcher_spec.rb
+++ b/spec/rack/i18n_locale_switcher_spec.rb
@@ -14,7 +14,7 @@ describe Rack::I18nLocaleSwitcher do
     rack = Rack::Builder.new do
       map "/" do
         use Rack::I18nLocaleSwitcher, opts
-        run lambda {|env| [200, {}, "Coolness"]}
+        run lambda { |env| [200, {}, "Coolness"] }
       end
     end
     rack.to_app
@@ -39,7 +39,7 @@ describe Rack::I18nLocaleSwitcher do
     }.to raise_error(ArgumentError, "Invalid option(s) :not_an_option")
 
     expect {
-      Rack::I18nLocaleSwitcher.new("app", :source => [:not_a_source])
+      Rack::I18nLocaleSwitcher.new("app", :source => [ :not_a_source ])
     }.to raise_error(ArgumentError, "Invalid source(s) :not_a_source")
 
     expect {
@@ -50,14 +50,14 @@ describe Rack::I18nLocaleSwitcher do
   context "with custom sources" do
 
     let :options do
-      { :source => [:header, :host] }
+      { :source => [ :header, :host ] }
     end
 
     it "should honor the sequence" do
-      get "http://de.example.com", nil, { "HTTP_ACCEPT_LANGUAGE" => "es" }
+      get "http://de.example.com" , nil, {"HTTP_ACCEPT_LANGUAGE" => "es"}
       I18n.locale.should eql(:es)
 
-      get "http://de.example.com", nil, { "HTTP_ACCEPT_LANGUAGE" => "foo" }
+      get "http://de.example.com" , nil, {"HTTP_ACCEPT_LANGUAGE" => "foo"}
       I18n.locale.should eql(:de)
 
       get "http://de.example.com"
@@ -129,10 +129,10 @@ describe Rack::I18nLocaleSwitcher do
   context "from accept-language header" do
 
     it "should override the client requested locale" do
-      get "http://example.com", nil, { "HTTP_ACCEPT_LANGUAGE" => "de-de,de,en;q=0.5" }
+      get "http://example.com" , nil, {"HTTP_ACCEPT_LANGUAGE" => "de-de,de,en;q=0.5"}
       I18n.locale.should eql(:'de-DE')
 
-      get "http://example.com", nil, { "HTTP_ACCEPT_LANGUAGE" => "en;q=0.5,en-US;q=0.8,es;q=0.7" }
+      get "http://example.com" , nil, {"HTTP_ACCEPT_LANGUAGE" => "en;q=0.5,en-US;q=0.8,es;q=0.7"}
       I18n.locale.should eql(:'en-US')
     end
   end
@@ -165,7 +165,7 @@ describe Rack::I18nLocaleSwitcher do
     end
 
     it "should not redirect if the locale was set in the accept header" do
-      get "http://example.com", nil, { "HTTP_ACCEPT_LANGUAGE" => "en" }
+      get "http://example.com" , nil, {"HTTP_ACCEPT_LANGUAGE" => "en"}
       last_response.should_not be_redirect
     end
   end
@@ -190,9 +190,9 @@ describe Rack::I18nLocaleSwitcher do
 
     it "should redirect if the locale was set by other means" do
       {
-        "http://en.example.com" => "http://example.com/en",
-        "http://en.example.com/de" => "http://example.com/de",
-        "http://de.example.com" => "http://example.com/de",
+        "http://en.example.com"        => "http://example.com/en",
+        "http://en.example.com/de"     => "http://example.com/de",
+        "http://de.example.com"        => "http://example.com/de",
         "http://example.com?locale=de" => "http://example.com/de"
       }.each do |url, redirect_url|
         get url
@@ -202,7 +202,7 @@ describe Rack::I18nLocaleSwitcher do
     end
 
     it "should redirect if the locale was set with an accept header" do
-      get "http://example.com", nil, { "HTTP_ACCEPT_LANGUAGE" => "de" }
+      get "http://example.com" , nil, {"HTTP_ACCEPT_LANGUAGE" => "de"}
       last_response.should be_redirect
       last_response.location.should eql("http://example.com/de")
     end
@@ -236,9 +236,9 @@ describe Rack::I18nLocaleSwitcher do
 
     it "should redirect if the locale was set by other means" do
       {
-        "http://example.com/en" => "http://en.example.com",
-        "http://en.example.com/de" => "http://de.example.com",
-        "http://example.com/de" => "http://de.example.com",
+        "http://example.com/en"        => "http://en.example.com",
+        "http://en.example.com/de"     => "http://de.example.com",
+        "http://example.com/de"        => "http://de.example.com",
         "http://example.com?locale=de" => "http://de.example.com"
       }.each do |url, redirect_url|
         get url
@@ -248,7 +248,7 @@ describe Rack::I18nLocaleSwitcher do
     end
 
     it "should redirect if the locale was set with an accept header" do
-      get "http://example.com", nil, { "HTTP_ACCEPT_LANGUAGE" => "de" }
+      get "http://example.com" , nil, {"HTTP_ACCEPT_LANGUAGE" => "de"}
       last_response.should be_redirect
       last_response.location.should eql("http://de.example.com")
     end
@@ -282,9 +282,9 @@ describe Rack::I18nLocaleSwitcher do
 
     it "should redirect if the locale was set by other means" do
       {
-        "http://example.com/en" => "http://example.com?locale=en",
-        "http://de.example.com/foo/bar" => "http://example.com/foo/bar?locale=de",
-        "http://example.com/de" => "http://example.com?locale=de",
+        "http://example.com/en"           => "http://example.com?locale=en",
+        "http://de.example.com/foo/bar"   => "http://example.com/foo/bar?locale=de",
+        "http://example.com/de"           => "http://example.com?locale=de",
         "http://en.example.com?locale=de" => "http://example.com?locale=de"
       }.each do |url, redirect_url|
         get url
@@ -294,7 +294,7 @@ describe Rack::I18nLocaleSwitcher do
     end
 
     it "should redirect if the locale was set with an accept header" do
-      get "http://example.com", nil, { "HTTP_ACCEPT_LANGUAGE" => "de" }
+      get "http://example.com" , nil, {"HTTP_ACCEPT_LANGUAGE" => "de"}
       last_response.should be_redirect
       last_response.location.should eql("http://example.com?locale=de")
     end
@@ -315,9 +315,9 @@ describe Rack::I18nLocaleSwitcher do
       end
 
       it "should not redirect if the path is exempt" do
-        ["http://example.com/assets",
-         "http://de.example.com/assets/foo/bar",
-         "http://example.com/assets/"
+        [ "http://example.com/assets",
+          "http://de.example.com/assets/foo/bar",
+          "http://example.com/assets/"
         ].each do |url|
           get url
           last_response.should_not be_redirect


### PR DESCRIPTION
### What does this PR do?

The current master would modify the env of rack even if not necessary.
Now path, host and query string stay untouched unless the settings of the Rack middleware ask for a redirect after extraction.